### PR TITLE
feat: add Kubernetes deployment, scaling, Ingress, blue-green and rolling update strategies for django-messaging-app

### DIFF
--- a/messaging_app/blue_deployment.yaml
+++ b/messaging_app/blue_deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: django-messaging-app-blue
+  labels:
+    app: django-messaging-app
+    version: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: django-messaging-app
+      version: blue
+  template:
+    metadata:
+      labels:
+        app: django-messaging-app
+        version: blue
+    spec:
+      containers:
+      - name: django-container
+        image: django-messaging-app:latest
+        ports:
+        - containerPort: 8000
+        env:
+        - name: DJANGO_SETTINGS_MODULE
+          value: "messaging.settings"

--- a/messaging_app/blue_deployment.yaml
+++ b/messaging_app/blue_deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: django-container
-        image: django-messaging-app:latest
+        image: django-messaging-app:2.0 
         ports:
         - containerPort: 8000
         env:

--- a/messaging_app/commands.txt
+++ b/messaging_app/commands.txt
@@ -1,0 +1,5 @@
+# Install NGINX Ingress Controller in Minikube
+minikube addons enable ingress
+
+# Apply the ingress configuration
+kubectl apply -f ingress.yaml

--- a/messaging_app/deployment.yaml
+++ b/messaging_app/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: django-messaging-app
+  labels:
+    app: django-messaging-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: django-messaging-app
+  template:
+    metadata:
+      labels:
+        app: django-messaging-app
+    spec:
+      containers:
+      - name: django-container
+        image: django-messaging-app:latest
+        ports:
+        - containerPort: 8000
+        env:
+        - name: DJANGO_SETTINGS_MODULE
+          value: "messaging.settings"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: django-messaging-service
+spec:
+  type: ClusterIP
+  selector:
+    app: django-messaging-app
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000

--- a/messaging_app/green_deployment.yaml
+++ b/messaging_app/green_deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: django-messaging-app-green
+  labels:
+    app: django-messaging-app
+    version: green
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: django-messaging-app
+      version: green
+  template:
+    metadata:
+      labels:
+        app: django-messaging-app
+        version: green
+    spec:
+      containers:
+      - name: django-container
+        image: django-messaging-app:v2  # New version image tag
+        ports:
+        - containerPort: 8000
+        env:
+        - name: DJANGO_SETTINGS_MODULE
+          value: "messaging.settings"

--- a/messaging_app/kubctl-0x02
+++ b/messaging_app/kubctl-0x02
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+BLUE_DEPLOYMENT="messaging_app/blue_deployment.yaml"
+GREEN_DEPLOYMENT="messaging_app/green_deployment.yaml"
+SERVICE="messaging_app/kubeservice.yaml"
+
+echo "Applying blue deployment..."
+kubectl apply -f $BLUE_DEPLOYMENT
+
+echo "Applying green deployment..."
+kubectl apply -f $GREEN_DEPLOYMENT
+
+echo "Applying service pointing to blue version..."
+kubectl apply -f $SERVICE
+
+echo "Waiting for pods to be ready..."
+sleep 10
+
+echo "Checking pods for errors..."
+kubectl get pods -l app=django-messaging-app
+
+echo "Checking logs of green deployment pods..."
+GREEN_PODS=$(kubectl get pods -l app=django-messaging-app,version=green -o jsonpath='{.items[*].metadata.name}')
+for pod in $GREEN_PODS; do
+  echo "Logs from $pod:"
+  kubectl logs $pod --tail=20
+done
+
+echo "Switching service selector to green version to shift traffic..."
+
+kubectl patch service django-messaging-app-service -p '{"spec":{"selector":{"app":"django-messaging-app","version":"green"}}}'
+
+echo "Blue-green deployment complete! Traffic is now routed to green version."

--- a/messaging_app/kubctl-0x03
+++ b/messaging_app/kubctl-0x03
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+DEPLOYMENT_FILE="messaging_app/blue_deployment.yaml"
+DEPLOYMENT_NAME="django-messaging-app-blue"
+SERVICE_NAME="django-messaging-app-service"
+PORT=8000
+
+echo "Applying updated deployment (image v2.0)..."
+kubectl apply -f $DEPLOYMENT_FILE
+
+echo "Starting port-forward in background..."
+kubectl port-forward service/$SERVICE_NAME $PORT:$PORT > /dev/null 2>&1 &
+PF_PID=$!
+
+# Give port-forward a few seconds to start
+sleep 3
+
+echo "Monitoring rollout status for $DEPLOYMENT_NAME..."
+kubectl rollout status deployment/$DEPLOYMENT_NAME &
+
+echo "Sending HTTP requests to test app availability during update..."
+for i in {1..20}; do
+  RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/)
+  echo "[$i] HTTP response code: $RESPONSE"
+  sleep 1
+done
+
+echo "Stopping port-forward..."
+kill $PF_PID
+
+echo "Current pods for deployment:"
+kubectl get pods -l app=django-messaging-app,version=blue
+
+echo "Rolling update completed without downtime."

--- a/messaging_app/kubeservice.yaml
+++ b/messaging_app/kubeservice.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: django-messaging-app-service
+spec:
+  type: ClusterIP
+  selector:
+    app: django-messaging-app
+    version: blue   # Initially points to blue deployment
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000

--- a/messaging_app/messaging_app/blue_deployment.yaml
+++ b/messaging_app/messaging_app/blue_deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: django-messaging-app-blue
+  labels:
+    app: django-messaging-app
+    version: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: django-messaging-app
+      version: blue
+  template:
+    metadata:
+      labels:
+        app: django-messaging-app
+        version: blue
+    spec:
+      containers:
+      - name: django-container
+        image: django-messaging-app:latest
+        ports:
+        - containerPort: 8000
+        env:
+        - name: DJANGO_SETTINGS_MODULE
+          value: "messaging.settings"

--- a/messaging_app/messaging_app/blue_deployment.yaml
+++ b/messaging_app/messaging_app/blue_deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: django-container
-        image: django-messaging-app:latest
+        image: django-messaging-app:2.0 
         ports:
         - containerPort: 8000
         env:

--- a/messaging_app/messaging_app/commands.txt
+++ b/messaging_app/messaging_app/commands.txt
@@ -1,0 +1,5 @@
+# Install NGINX Ingress Controller in Minikube
+minikube addons enable ingress
+
+# Apply the ingress configuration
+kubectl apply -f ingress.yaml

--- a/messaging_app/messaging_app/green_deployment.yaml
+++ b/messaging_app/messaging_app/green_deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: django-messaging-app-green
+  labels:
+    app: django-messaging-app
+    version: green
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: django-messaging-app
+      version: green
+  template:
+    metadata:
+      labels:
+        app: django-messaging-app
+        version: green
+    spec:
+      containers:
+      - name: django-container
+        image: django-messaging-app:v2  # New version image tag
+        ports:
+        - containerPort: 8000
+        env:
+        - name: DJANGO_SETTINGS_MODULE
+          value: "messaging.settings"

--- a/messaging_app/messaging_app/ingress.yaml
+++ b/messaging_app/messaging_app/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: django-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+  - host: django.local
+    http:
+      paths:
+      - path: /api/(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: django-messaging-service
+            port:
+              number: 8000

--- a/messaging_app/messaging_app/kubctl-0x02
+++ b/messaging_app/messaging_app/kubctl-0x02
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+BLUE_DEPLOYMENT="messaging_app/blue_deployment.yaml"
+GREEN_DEPLOYMENT="messaging_app/green_deployment.yaml"
+SERVICE="messaging_app/kubeservice.yaml"
+
+echo "Applying blue deployment..."
+kubectl apply -f $BLUE_DEPLOYMENT
+
+echo "Applying green deployment..."
+kubectl apply -f $GREEN_DEPLOYMENT
+
+echo "Applying service pointing to blue version..."
+kubectl apply -f $SERVICE
+
+echo "Waiting for pods to be ready..."
+sleep 10
+
+echo "Checking pods for errors..."
+kubectl get pods -l app=django-messaging-app
+
+echo "Checking logs of green deployment pods..."
+GREEN_PODS=$(kubectl get pods -l app=django-messaging-app,version=green -o jsonpath='{.items[*].metadata.name}')
+for pod in $GREEN_PODS; do
+  echo "Logs from $pod:"
+  kubectl logs $pod --tail=20
+done
+
+echo "Switching service selector to green version to shift traffic..."
+
+kubectl patch service django-messaging-app-service -p '{"spec":{"selector":{"app":"django-messaging-app","version":"green"}}}'
+
+echo "Blue-green deployment complete! Traffic is now routed to green version."

--- a/messaging_app/messaging_app/kubctl-0x03
+++ b/messaging_app/messaging_app/kubctl-0x03
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+DEPLOYMENT_FILE="messaging_app/blue_deployment.yaml"
+DEPLOYMENT_NAME="django-messaging-app-blue"
+SERVICE_NAME="django-messaging-app-service"
+PORT=8000
+
+echo "Applying updated deployment (image v2.0)..."
+kubectl apply -f $DEPLOYMENT_FILE
+
+echo "Starting port-forward in background..."
+kubectl port-forward service/$SERVICE_NAME $PORT:$PORT > /dev/null 2>&1 &
+PF_PID=$!
+
+# Give port-forward a few seconds to start
+sleep 3
+
+echo "Monitoring rollout status for $DEPLOYMENT_NAME..."
+kubectl rollout status deployment/$DEPLOYMENT_NAME &
+
+echo "Sending HTTP requests to test app availability during update..."
+for i in {1..20}; do
+  RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/)
+  echo "[$i] HTTP response code: $RESPONSE"
+  sleep 1
+done
+
+echo "Stopping port-forward..."
+kill $PF_PID
+
+echo "Current pods for deployment:"
+kubectl get pods -l app=django-messaging-app,version=blue
+
+echo "Rolling update completed without downtime."

--- a/messaging_app/messaging_app/kubeservice.yaml
+++ b/messaging_app/messaging_app/kubeservice.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: django-messaging-app-service
+spec:
+  type: ClusterIP
+  selector:
+    app: django-messaging-app
+    version: blue   # Initially points to blue deployment
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000


### PR DESCRIPTION
Summary
This PR introduces full Kubernetes support for the `django-messaging-app`, including initial cluster setup, deployments, services, Ingress exposure, blue-green deployment strategy, and zero-downtime rolling updates.
Added Files and Features
1. **Cluster Initialization and Verification**
* `kurbeScript.sh`: Script to start Minikube, verify Kubernetes status with `kubectl`, and list running pods.
2. **Django App Deployment**
* `deployment.yaml` → renamed to `blue_deployment.yaml`: Defines a basic deployment of the app with 2 replicas.
* `kubeservice.yaml`: Exposes the app internally using a `ClusterIP` service on port 8000.
3. **Scaling and Load Testing**
* `kubctl-0x01`:
   * Scales the app to 3 replicas using `kubectl scale`.
   * Performs load testing with `wrk`.
   * Monitors pod resource usage via `kubectl top`.
4. **Ingress Exposure**
* `ingress.yaml`:
   * Adds NGINX Ingress configuration to route `/api/` traffic to the internal service.
* `commands.txt`:
   * Documents the commands used to install the NGINX Ingress controller and apply the Ingress config.
5. **Blue-Green Deployment Strategy**
* `blue_deployment.yaml`: Existing app version (v1 or latest).
* `green_deployment.yaml`: New app version (v2) deployed alongside blue.
* `kubeservice.yaml`: Shared Service that can be pointed to either version via label selector.
* `kubctl-0x02`:
   * Deploys both blue and green versions.
   * Shows logs from green pods.
   * Switches service traffic from blue to green.
6. **Rolling Update Strategy**
* Updated `blue_deployment.yaml` to use `django-messaging-app:2.0`.
* `kubctl-0x03`:
   * Applies the updated deployment.
   * Monitors the rollout via `kubectl rollout status`.
   * Sends continuous curl requests to check for downtime.
   * Displays current pods after the rollout completes.