### PR TITLE
ci/cd: add Jenkins pipeline and GitHub Actions workflows for testing, linting, and Docker builds

### DIFF
--- a/messaging_app/Jenkinsfile
+++ b/messaging_app/Jenkinsfile
@@ -12,13 +12,19 @@ pipeline {
             }
         }
 
+        stage('Show Git Branch') {
+            steps {
+                sh 'git branch'
+            }
+        }
+
         stage('Setup Python Env') {
             steps {
                 sh '''
                     python3 -m venv ${VENV_DIR}
                     . ${VENV_DIR}/bin/activate
-                    pip install --upgrade pip
-                    pip install -r messaging_app/requirements.txt
+                    pip3 install --upgrade pip
+                    pip3 install -r messaging_app/requirements.txt
                 '''
             }
         }

--- a/messaging_app/Jenkinsfile
+++ b/messaging_app/Jenkinsfile
@@ -3,6 +3,8 @@ pipeline {
 
     environment {
         VENV_DIR = 'venv'
+        DOCKER_IMAGE = 'yourdockerhubusername/messaging-app'
+        DOCKER_TAG = "latest" // You can use build number or git commit hash here for versioning
     }
 
     stages {
@@ -41,6 +43,24 @@ pipeline {
         stage('Publish Report') {
             steps {
                 junit 'report.xml'
+            }
+        }
+
+        stage('Build Docker Image') {
+            steps {
+                script {
+                    docker.build("${DOCKER_IMAGE}:${DOCKER_TAG}")
+                }
+            }
+        }
+
+        stage('Push Docker Image') {
+            steps {
+                script {
+                    docker.withRegistry('https://registry.hub.docker.com', 'dockerhub-creds') {
+                        docker.image("${DOCKER_IMAGE}:${DOCKER_TAG}").push()
+                    }
+                }
             }
         }
     }

--- a/messaging_app/Jenkinsfile
+++ b/messaging_app/Jenkinsfile
@@ -1,0 +1,47 @@
+pipeline {
+    agent any
+
+    environment {
+        VENV_DIR = 'venv'
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                git credentialsId: 'github-creds', url: 'https://github.com/meekjames/alx-backend-python.git', branch: 'main'
+            }
+        }
+
+        stage('Setup Python Env') {
+            steps {
+                sh '''
+                    python3 -m venv ${VENV_DIR}
+                    . ${VENV_DIR}/bin/activate
+                    pip install --upgrade pip
+                    pip install -r messaging_app/requirements.txt
+                '''
+            }
+        }
+
+        stage('Run Tests') {
+            steps {
+                sh '''
+                    . ${VENV_DIR}/bin/activate
+                    pytest messaging_app/tests --junitxml=report.xml
+                '''
+            }
+        }
+
+        stage('Publish Report') {
+            steps {
+                junit 'report.xml'
+            }
+        }
+    }
+
+    post {
+        always {
+            echo 'Pipeline finished!'
+        }
+    }
+}

--- a/messaging_app/messaging_app/Jenkinsfile
+++ b/messaging_app/messaging_app/Jenkinsfile
@@ -12,13 +12,19 @@ pipeline {
             }
         }
 
+        stage('Show Git Branch') {
+            steps {
+                sh 'git branch'
+            }
+        }
+
         stage('Setup Python Env') {
             steps {
                 sh '''
                     python3 -m venv ${VENV_DIR}
                     . ${VENV_DIR}/bin/activate
-                    pip install --upgrade pip
-                    pip install -r messaging_app/requirements.txt
+                    pip3 install --upgrade pip
+                    pip3 install -r messaging_app/requirements.txt
                 '''
             }
         }

--- a/messaging_app/messaging_app/Jenkinsfile
+++ b/messaging_app/messaging_app/Jenkinsfile
@@ -3,6 +3,8 @@ pipeline {
 
     environment {
         VENV_DIR = 'venv'
+        DOCKER_IMAGE = 'yourdockerhubusername/messaging-app'
+        DOCKER_TAG = "latest" // You can use build number or git commit hash here for versioning
     }
 
     stages {
@@ -41,6 +43,24 @@ pipeline {
         stage('Publish Report') {
             steps {
                 junit 'report.xml'
+            }
+        }
+
+        stage('Build Docker Image') {
+            steps {
+                script {
+                    docker.build("${DOCKER_IMAGE}:${DOCKER_TAG}")
+                }
+            }
+        }
+
+        stage('Push Docker Image') {
+            steps {
+                script {
+                    docker.withRegistry('https://registry.hub.docker.com', 'dockerhub-creds') {
+                        docker.image("${DOCKER_IMAGE}:${DOCKER_TAG}").push()
+                    }
+                }
             }
         }
     }

--- a/messaging_app/messaging_app/Jenkinsfile
+++ b/messaging_app/messaging_app/Jenkinsfile
@@ -1,0 +1,47 @@
+pipeline {
+    agent any
+
+    environment {
+        VENV_DIR = 'venv'
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                git credentialsId: 'github-creds', url: 'https://github.com/meekjames/alx-backend-python.git', branch: 'main'
+            }
+        }
+
+        stage('Setup Python Env') {
+            steps {
+                sh '''
+                    python3 -m venv ${VENV_DIR}
+                    . ${VENV_DIR}/bin/activate
+                    pip install --upgrade pip
+                    pip install -r messaging_app/requirements.txt
+                '''
+            }
+        }
+
+        stage('Run Tests') {
+            steps {
+                sh '''
+                    . ${VENV_DIR}/bin/activate
+                    pytest messaging_app/tests --junitxml=report.xml
+                '''
+            }
+        }
+
+        stage('Publish Report') {
+            steps {
+                junit 'report.xml'
+            }
+        }
+    }
+
+    post {
+        always {
+            echo 'Pipeline finished!'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds CI/CD automation for the `messaging_app` project using **Jenkins** and **GitHub Actions**.

### Jenkins
- Added `Jenkinsfile` with pipeline stages:
  - Pull source code from GitHub
  - Install dependencies
  - Run tests with pytest
  - Generate test report
  - Build and push Docker image to Docker Hub

### GitHub Actions
- Added `.github/workflows/ci.yml`
  - Runs Django tests on every push & PR
  - Spins up MySQL service for integration tests
  - Runs flake8 linting (build fails on errors)
  - Runs coverage and uploads coverage report as artifact
- Added `.github/workflows/dep.yml`
  - Builds and pushes Docker image to Docker Hub
  - Uses GitHub Actions secrets for Docker credentials

### Files Added
- `messaging_app/Jenkinsfile`
- `messaging_app/.github/workflows/ci.yml`
- `messaging_app/.github/workflows/dep.yml`
- `messaging_app/Dockerfile`

### Benefits
- Automated test execution and reporting
- Enforced code quality via flake8
- Coverage reports available in CI
- Automated Docker image builds for deployments
- Secure use of GitHub secrets for Docker Hub authentication
